### PR TITLE
Disallow updating a travelnet for players who cannot use it

### DIFF
--- a/locked_travelnet.lua
+++ b/locked_travelnet.lua
@@ -87,6 +87,9 @@ minetest.register_node("locked_travelnet:travelnet", {
     end,
 
     on_punch          = function(pos, node, puncher)
+                          if not locks:lock_allow_use( pos, puncher ) then
+                              return false
+                          end
                           travelnet.update_formspec(pos, puncher:get_player_name())
     end,
 


### PR DESCRIPTION
Fixes https://github.com/BlockySurvival/issue-tracker/issues/339
Actually fixes https://github.com/BlockySurvival/issue-tracker/issues/121 this time