### PR TITLE
Try to fix "fly" bug

### DIFF
--- a/locked_travelnet.lua
+++ b/locked_travelnet.lua
@@ -162,7 +162,10 @@ minetest.register_node("locked_travelnet:travelnet", {
 	end,
 
 	after_dig_node = function (pos, oldnode, oldmetadata, digger)
-		travelnet.remove_box( pos, oldnode, oldmetadata, digger )
+		local above = vector.add(pos, vector.new(0, 1, 0))
+		if minetest.get_node(above).name == "travelnet:hidden_top" then
+			minetest.remove_node(above)
+		end
 	end,
 
 	on_destruct = function (pos)

--- a/locked_travelnet.lua
+++ b/locked_travelnet.lua
@@ -162,14 +162,14 @@ minetest.register_node("locked_travelnet:travelnet", {
 	end,
 
 	after_dig_node = function (pos, oldnode, oldmetadata, digger)
+		travelnet.remove_box( pos, oldnode, oldmetadata, digger )
+	end,
+
+	on_destruct = function (pos)
 		local above = vector.add(pos, vector.new(0, 1, 0))
 		if minetest.get_node(above).name == "travelnet:hidden_top" then
 			minetest.remove_node(above)
 		end
-	end,
-
-	on_destruct = function (pos)
-		minetest.remove_node({x=pos.x, y=pos.y+1, z=pos.z})
 	end,
 
 	-- taken from VanessaEs homedecor fridge

--- a/locked_travelnet.lua
+++ b/locked_travelnet.lua
@@ -165,6 +165,10 @@ minetest.register_node("locked_travelnet:travelnet", {
 		travelnet.remove_box( pos, oldnode, oldmetadata, digger )
 	end,
 
+	on_destruct = function (pos)
+		minetest.remove_node({x=pos.x, y=pos.y+1, z=pos.z})
+	end,
+
 	-- taken from VanessaEs homedecor fridge
 	on_place = function (itemstack, placer, pointed_thing)
 		local pos = pointed_thing.above;


### PR DESCRIPTION
When we delete a travelnet here, the upper node (or vector or whatever) of the travelnet is not removed and invisible. This causes a problem where we can't build at that position and seem to "float" in the air.  
This pull request just fixes that bug. 

Closes https://github.com/BlockySurvival/issue-tracker/issues/404